### PR TITLE
OPENEUROPA-2464: Use PHP 7.1 in docker-compose.

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.2
+    image: fpfis/httpd-php-dev:7.1
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.1 again in docker-compose.